### PR TITLE
[APPR-37] 공통 예외 처리 구조 구현

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/BusinessException.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/BusinessException.java
@@ -1,0 +1,14 @@
+package com.whatthefork.approvalsystem.common.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.whatthefork.approvalsystem.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002","서버 내부 오류가 발생했습니다."),
+
+    // Document
+    DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "해당 문서를 찾을 수 없습니다."),
+    CANNOT_MODIFY_DOCUMENT(HttpStatus.BAD_REQUEST, "D002", "임시저장 상태의 문서만 수정할 수 있습니다."),
+    CANNOT_DELETE_DOCUMENT(HttpStatus.BAD_REQUEST, "D003", "이미 결재가 진행된 문서는 삭제할 수 없습니다."),
+
+    // Auth
+    NOT_DRAFTER(HttpStatus.FORBIDDEN, "A001", "본인의 문서만 수정/삭제할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorResponse.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorResponse.java
@@ -1,0 +1,30 @@
+package com.whatthefork.approvalsystem.common.error;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String message;
+    private final String code;
+
+    @Builder
+    public ErrorResponse(int status, String message, String code) {
+        this.timestamp = LocalDateTime.now();
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/GlobalExceptionHandler.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.whatthefork.approvalsystem.common.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /* BusinessException 처리 */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException ex) {
+        log.error("handleBusinessException 에러 발생", ex);
+        log.error("BusinessException - Code: {}, Message: {}", ex.getErrorCode().getCode(), ex.getMessage());
+
+        ErrorCode errorcode = ex.getErrorCode();
+
+        ErrorResponse response = ErrorResponse.of(errorcode);
+
+        return ResponseEntity
+                .status(errorcode.getStatus())
+                .body(response);
+    }
+
+    /* 그 외 에러 전역 처리 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("handleException 에러 발생", ex);
+
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorResponse response = ErrorResponse.of(errorCode);
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(response);
+    }
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -5,20 +5,16 @@ import com.whatthefork.approvalsystem.dto.request.CreateDocumentRequestDto;
 import com.whatthefork.approvalsystem.dto.request.UpdateDocumentRequestDto;
 import com.whatthefork.approvalsystem.service.DocumentService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/document")
+@RequiredArgsConstructor
 public class DocumentController {
 
-    @Autowired
     private final DocumentService documentService;
-
-    public DocumentController(DocumentService documentService) {
-        this.documentService = documentService;
-    }
 
     /* 12.06 모든 메소드의 매개변수에 userId 대신 @AuthenticationPrincipal UserDetailsImpl로 로그인된 사용자 정보에서 Id 추출할 예정. 현재는 임시 기입 */
     @PostMapping("/drafting")

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalLine.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalLine.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Column;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #36 

## #️⃣ 작업 내용
- 기존 존재하던 `IllegalArgumentException` 대신 커스텀 에러 코드 작성하여 표준화된 규격으로 반환하도록 수정
- `DocumentService` 내 예외 처리를 하나의 메소드로 구현하여 중복 코드 제거

## #️⃣ 참고 내용

- 서비스 계층 내 결재자 관련 검증 로직은 엔터티 계층에서 하도록 수정할 계획입니다.
