### PR TITLE
[APPR-38] DocumentService 검증 책임 분리 및 중복 코드 메소드화

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "해당 문서를 찾을 수 없습니다."),
     CANNOT_MODIFY_DOCUMENT(HttpStatus.BAD_REQUEST, "D002", "임시저장 상태의 문서만 수정할 수 있습니다."),
     CANNOT_DELETE_DOCUMENT(HttpStatus.BAD_REQUEST, "D003", "이미 결재가 진행된 문서는 삭제할 수 없습니다."),
+    APPROVER_REQUIRED(HttpStatus.BAD_REQUEST, "D004", "결재자를 지정해야 합니다."),
+    INVALID_APPROVER_COUNT(HttpStatus.BAD_REQUEST, "D005", "결재자는 반드시 3명이어야 합니다."),
 
     // Auth
     NOT_DRAFTER(HttpStatus.FORBIDDEN, "A001", "본인의 문서만 수정/삭제할 수 있습니다.");

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalDocument.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalDocument.java
@@ -86,4 +86,12 @@ public class ApprovalDocument {
     public void deleteDocument() {
         this.isDeleted = true;
     }
+
+    public boolean isSameDrafter(Long userId) {
+        return this.drafter.equals(userId);
+    }
+
+    public boolean isTempStatus() {
+        return this.docStatus == DocStatusEnum.TEMP;
+    }
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalLine.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalLine.java
@@ -1,13 +1,7 @@
 package com.whatthefork.approvalsystem.domain;
 
 import com.whatthefork.approvalsystem.enums.LineStatusEnum;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Column;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #38

## #️⃣ 작업 내용

- 기안 문서 검증 로직을 `ApprovalDocument`로 boolean을 반환하도록 분리 후 서비스 계층에서 검증 메소드 생성
- 결재선 생성 로직을 메소드로 추출하여 중복 코드 제거

## #️⃣ 참고사항

-  `ApprovalLine` 클래스에서 갑자기 자동으로 import가 `*`로 바뀌었는데 하나하나 쳐도 지 알아서 바뀝니다 ..
