### PR TITLE
[APPR-45] 문서 상세 조회 및 임시 저장된 기안 페이징 로직 구현

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -3,9 +3,13 @@ package com.whatthefork.approvalsystem.controller;
 import com.whatthefork.approvalsystem.common.ApiResponse;
 import com.whatthefork.approvalsystem.dto.request.CreateDocumentRequestDto;
 import com.whatthefork.approvalsystem.dto.request.UpdateDocumentRequestDto;
+import com.whatthefork.approvalsystem.dto.response.DocumentDetailResponseDto;
+import com.whatthefork.approvalsystem.dto.response.DocumentListResponseDto;
 import com.whatthefork.approvalsystem.service.DocumentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,20 +22,34 @@ public class DocumentController {
 
     /* 12.06 모든 메소드의 매개변수에 userId 대신 @AuthenticationPrincipal UserDetailsImpl로 로그인된 사용자 정보에서 Id 추출할 예정. 현재는 임시 기입 */
     @PostMapping("/drafting")
-    public ResponseEntity<ApiResponse> createDocument(Long userId, @RequestBody @Valid CreateDocumentRequestDto requestDto) {
-        Long docId = documentService.createDocument(userId, requestDto);
+    public ResponseEntity<ApiResponse> createDocument(/*Long userId, */@RequestBody @Valid CreateDocumentRequestDto requestDto) {
+        /* 12.07 security 완성 전까지 임시 유저 ID는 1로 고정해서 API 테스트 */
+        Long memberId = 1L;
+        Long docId = documentService.createDocument(memberId, requestDto);
         return ResponseEntity.ok(ApiResponse.success(docId));
     }
 
     @PutMapping("/{docId}")
-    public ResponseEntity<ApiResponse> updateDocument(Long userId, @PathVariable Long docId, @RequestBody @Valid UpdateDocumentRequestDto requestDto) {
-        documentService.updateDocument(userId, docId, requestDto);
+    public ResponseEntity<ApiResponse> updateDocument(Long memberId, @PathVariable Long docId, @RequestBody @Valid UpdateDocumentRequestDto requestDto) {
+        documentService.updateDocument(memberId, docId, requestDto);
         return ResponseEntity.ok(ApiResponse.success("기안 수정 완료"));
     }
 
     @DeleteMapping("/{docId}")
-    public ResponseEntity<ApiResponse> deleteDocument(Long userId, @PathVariable Long docId) {
-        documentService.deleteDocument(userId, docId);
+    public ResponseEntity<ApiResponse> deleteDocument(Long memberId, @PathVariable Long docId) {
+        documentService.deleteDocument(memberId, docId);
         return ResponseEntity.ok(ApiResponse.success("기안 삭제 완료"));
+    }
+
+    @GetMapping("/{docId}")
+    public ResponseEntity<ApiResponse> getDocumentDetail(Long memberId, @PathVariable Long docId) {
+        DocumentDetailResponseDto response = documentService.readDetailDocument(memberId, docId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/drafts")
+    public ResponseEntity<ApiResponse> getDocumentList(Long memberId, Pageable pageable) {
+        Page<DocumentListResponseDto> documentList = documentService.getTempDocumentList(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(documentList));
     }
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/member/MemberRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/member/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.whatthefork.approvalsystem.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    String findByName(String name);
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/request/CreateDocumentRequestDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/request/CreateDocumentRequestDto.java
@@ -26,10 +26,10 @@ public class CreateDocumentRequestDto {
     // 참조자, 선택사항
     private List<Long> referrer;
 
-    @NotBlank(message = "휴가 시작 일자는 필수로 지정해야 합니다.")
+    @NotNull(message = "휴가 시작 일자는 필수로 지정해야 합니다.")
     private LocalDate startVacationDate;
 
-    @NotBlank(message = "휴가 종료 일자는 필수로 지정해야 합니다.")
+    @NotNull(message = "휴가 종료 일자는 필수로 지정해야 합니다.")
     private LocalDate endVacationDate;
 
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/ApprovalLineResponseDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/ApprovalLineResponseDto.java
@@ -1,0 +1,19 @@
+package com.whatthefork.approvalsystem.dto.response;
+
+import com.whatthefork.approvalsystem.enums.LineStatusEnum;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ApprovalLineResponseDto {
+
+    private Long approverId;
+    private String approverName;
+    private int sequence;
+    private LineStatusEnum status;
+    private LocalDateTime approvedAt;
+
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentDetailResponseDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentDetailResponseDto.java
@@ -1,0 +1,35 @@
+package com.whatthefork.approvalsystem.dto.response;
+
+import com.whatthefork.approvalsystem.enums.DocStatusEnum;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class DocumentDetailResponseDto {
+
+    // 문서 기본 정보
+    private Long documentId;
+    private String title;
+    private String content;
+    private DocStatusEnum docStatus;
+
+    // 기안자 정보
+    private Long drafterId;
+
+    // 날짜 정보
+    private LocalDate startVacationDate;
+    private LocalDate endVacationDate;
+    private LocalDateTime createdAt;
+
+    // 결재자, 참조자
+    private List<ApprovalLineResponseDto> approvers;
+    private List<ReferrerResponseDto> referrers;
+
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentListResponseDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentListResponseDto.java
@@ -1,0 +1,18 @@
+package com.whatthefork.approvalsystem.dto.response;
+
+import com.whatthefork.approvalsystem.enums.DocStatusEnum;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DocumentListResponseDto {
+
+    private Long documentId;
+    private String title;
+    private DocStatusEnum status;
+    private LocalDateTime createdDate;
+
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/ReferrerResponseDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/ReferrerResponseDto.java
@@ -1,0 +1,15 @@
+package com.whatthefork.approvalsystem.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ReferrerResponseDto {
+
+    private Long referrerId;
+    private String referrerName;
+    private LocalDateTime viewedAt;
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
@@ -1,10 +1,15 @@
 package com.whatthefork.approvalsystem.repository;
 
 import com.whatthefork.approvalsystem.domain.ApprovalDocument;
+import com.whatthefork.approvalsystem.enums.DocStatusEnum;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ApprovalDocumentRepository extends JpaRepository<ApprovalDocument, Long> {
     Optional<ApprovalDocument> findById(long id);
+
+    Page<ApprovalDocument> findByDocStatusAndDrafterOrderByCreatedAtDesc(DocStatusEnum docStatus, Long drafter, Pageable pageable);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ApprovalLineRepository extends JpaRepository<ApprovalLine, Long> {
     @Query("DELETE FROM ApprovalLine al WHERE al.document = :docId")
     @Modifying(clearAutomatically = true)
     void deleteByDocumentId(@Param("docId") Long docId);
+
+    List<ApprovalLine> findByDocumentOrderBySequence(Long document);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalReferrerRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalReferrerRepository.java
@@ -3,5 +3,8 @@ package com.whatthefork.approvalsystem.repository;
 import com.whatthefork.approvalsystem.domain.ApprovalReferrer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ApprovalReferrerRepository extends JpaRepository<ApprovalReferrer, Long> {
+    List<ApprovalReferrer> findByDocumentOrderByViewedAt(Long documentId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #49 

## #️⃣ 작업 내용

- 기안문 본문과 함께 `Approvers` 및 `Referrers` 정보를 한 번에 조회하도록 구현 (관련 DTO 클래스 생성)
- 로그인한 사용자가 작성한 임시저장 상태의 문서를 최신순으로 조회하는 로직 구현
- `Pageable`을 적용하여 추후 대량의 데이터 조회 시 성능 저하 대비
