### PR TITLE
[APPR-50] 진행중인 기안 조회 로직 및 완결(결재, 반려)된 기안 조회 로직 구현

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/request/UpdateDocumentRequestDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/request/UpdateDocumentRequestDto.java
@@ -23,10 +23,10 @@ public class UpdateDocumentRequestDto {
     @NotBlank(message = "내용은 필수로 입력해야 합니다.")
     private String content;
 
-    @NotBlank(message = "휴가 시작 일자는 필수로 지정해야 합니다.")
+    @NotNull(message = "휴가 시작 일자는 필수로 지정해야 합니다.")
     private LocalDate startVacationDate;
 
-    @NotBlank(message = "휴가 종료 일자는 필수로 지정해야 합니다.")
+    @NotNull(message = "휴가 종료 일자는 필수로 지정해야 합니다.")
     private LocalDate endVacationDate;
 
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
@@ -14,5 +14,5 @@ public interface ApprovalDocumentRepository extends JpaRepository<ApprovalDocume
 
     Page<ApprovalDocument> findByDocStatusAndDrafterOrderByCreatedAtDesc(DocStatusEnum docStatus, Long drafter, Pageable pageable);
 
-    Page<ApprovalDocument> findByDocStatusAndDocStatusIn(Long drafter, List<DocStatusEnum> statusEnumList, Pageable pageable);
+    Page<ApprovalDocument> findByDrafterAndDocStatusInOrderByCreatedAtDesc(Long drafter, List<DocStatusEnum> statusEnumList, Pageable pageable);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
@@ -185,7 +185,7 @@ public class DocumentService {
     @Transactional(readOnly = true)
     public Page<DocumentListResponseDto> getClosedDocumentList(Long memberId, Pageable pageable) {
         List<DocStatusEnum> statuses = Arrays.asList(DocStatusEnum.APPROVED, DocStatusEnum.REJECTED);
-        Page<ApprovalDocument> documentList = approvalDocumentRepository.findByDocStatusAndDocStatusIn(memberId, statuses, pageable);
+        Page<ApprovalDocument> documentList = approvalDocumentRepository.findByDrafterAndDocStatusInOrderByCreatedAtDesc(memberId, statuses, pageable);
 
         return getResponseDto(documentList);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #58 

## #️⃣ 작업 내용

- `TEMP` 상태인 기안 문서를 작성자 기준으로 페이징 조회하는 메소드, API 구현
- `IN_PROGRESS` 상태인 기안 문서를 작성자 기준으로 페이징 조회하는 메소드, API 구현
- `APPROVED` 또는 `REJECTED` 상태의 문서를 작성자 기준으로 페이징 조회하는, API 구현
