### PR TITLE
[APPR-52] 기안 생성 시 중복 결재자가 2번 등록되는 오류 방지 에러 처리 추가

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     // Common
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002","서버 내부 오류가 발생했습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "해당 사용자를 찾을 수 없습니다."),
 
     // Document
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "해당 문서를 찾을 수 없습니다."),
@@ -17,6 +18,7 @@ public enum ErrorCode {
     CANNOT_DELETE_DOCUMENT(HttpStatus.BAD_REQUEST, "D003", "이미 결재가 진행된 문서는 삭제할 수 없습니다."),
     APPROVER_REQUIRED(HttpStatus.BAD_REQUEST, "D004", "결재자를 지정해야 합니다."),
     INVALID_APPROVER_COUNT(HttpStatus.BAD_REQUEST, "D005", "결재자는 반드시 3명이어야 합니다."),
+    DRAFTER_EQUALS_APPROVER(HttpStatus.BAD_REQUEST, "D006", "본인은 결재자로 등록할 수 없습니다."),
 
     // Auth
     NOT_DRAFTER(HttpStatus.FORBIDDEN, "A001", "본인의 문서만 수정/삭제할 수 있습니다.");

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -24,49 +24,49 @@ public class DocumentController {
     @PostMapping("/drafting")
     public ResponseEntity<ApiResponse> createDocument(/*Long userId, */@RequestBody @Valid CreateDocumentRequestDto requestDto) {
         /* 12.07 security 완성 전까지 임시 유저 ID는 1로 고정해서 API 테스트 */
-        Long memberId = 1L;
+        Long memberId = 101L;
         Long docId = documentService.createDocument(memberId, requestDto);
         return ResponseEntity.ok(ApiResponse.success(docId));
     }
 
     @PutMapping("/{docId}")
     public ResponseEntity<ApiResponse> updateDocument(/*Long memberId*/ @PathVariable Long docId, @RequestBody @Valid UpdateDocumentRequestDto requestDto) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         documentService.updateDocument(memberId, docId, requestDto);
         return ResponseEntity.ok(ApiResponse.success("기안 수정 완료"));
     }
 
     @DeleteMapping("/{docId}")
     public ResponseEntity<ApiResponse> deleteDocument(/*Long memberId,*/ @PathVariable Long docId) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         documentService.deleteDocument(memberId, docId);
         return ResponseEntity.ok(ApiResponse.success("기안 삭제 완료"));
     }
 
     @GetMapping("/{docId}")
     public ResponseEntity<ApiResponse> getDocumentDetail(/*Long memberId,*/ @PathVariable Long docId) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         DocumentDetailResponseDto response = documentService.readDetailDocument(memberId, docId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/drafts")
     public ResponseEntity<ApiResponse> getTempDocumentList(/*Long memberId,*/ Pageable pageable) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         Page<DocumentListResponseDto> documentList = documentService.getTempDocumentList(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(documentList));
     }
 
     @GetMapping("/progress")
     public ResponseEntity<ApiResponse> getProgressDocumentList(/*Long memberId,*/ Pageable pageable) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         Page<DocumentListResponseDto> documentList = documentService.getProgressDocumentList(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(documentList));
     }
 
     @GetMapping("/closed")
     public ResponseEntity<ApiResponse> getClosedDocumentList(/*Long memberId,*/ Pageable pageable) {
-        Long memberId = 1L;
+        Long memberId = 101L;
         Page<DocumentListResponseDto> documentList = documentService.getClosedDocumentList(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(documentList));
     }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/member/MemberRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/member/MemberRepository.java
@@ -2,7 +2,11 @@ package com.whatthefork.approvalsystem.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MemberRepository extends JpaRepository<Member,Long> {
 
     String findByName(String name);
+
+    long countAllByIdIn(List<Long> approvalIds);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #64 

## #️⃣ 작업 내용

- 결재선에 기안자 본인 ID가 포함되는 것을 금지하는 유효성 검사를 추가
- 요청된 모든 결재자 ID가 Member 테이블에 실존하는지 확인하는 DB 정합성 검증 로직을 추가
- 결재선 생성 시 문서의 존재 여부를 재확인하는 로직 추가
