### PR TITLE
[APPR-58] 결재자 및 참조자로 지정된 사원의 문서 열람 로직 구현

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
@@ -21,10 +21,13 @@ public enum ErrorCode {
     DRAFTER_EQUALS_APPROVER(HttpStatus.BAD_REQUEST, "D006", "본인은 결재자로 등록할 수 없습니다."),
 
     // Approval
-    CANNOT_CANCLE_SUBMIT(HttpStatus.BAD_REQUEST, "A001", "결재자가 읽은 문서는 상신을 취소할 수 없습니다."),
+    CANNOT_CANCLE_SUBMIT(HttpStatus.BAD_REQUEST, "P001", "결재자가 읽은 문서는 상신을 취소할 수 없습니다."),
+    NOT_MATCH_APPROVER(HttpStatus.BAD_REQUEST, "P002", "해당 문서의 결재자만 기안을 열람할 수 있습니다."),
+    NOT_MATCH_REFERRER(HttpStatus.BAD_REQUEST, "P003", "해당 문서의 참조자만 기안을 열람할 수 있습니다."),
 
     // Auth
-    NOT_DRAFTER(HttpStatus.FORBIDDEN, "A001", "본인의 문서만 수정/삭제할 수 있습니다.");
+    NOT_DRAFTER(HttpStatus.FORBIDDEN, "A001", "본인의 문서만 수정/삭제할 수 있습니다."),
+    NO_READ_AUTHORIZATION(HttpStatus.BAD_REQUEST, "A002", "문서 열람의 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -46,6 +46,7 @@ public class DocumentController {
     @GetMapping("/{docId}")
     public ResponseEntity<ApiResponse> getDocumentDetail(/*Long memberId,*/ @PathVariable Long docId) {
         Long memberId = 101L;
+        documentService.writeHistory(memberId, docId);
         DocumentDetailResponseDto response = documentService.readDetailDocument(memberId, docId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalHistory.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalHistory.java
@@ -35,7 +35,7 @@ public class ApprovalHistory {
     private Long actor;
 
     @Column(nullable = false)
-    private LocalDateTime openDate;
+    private LocalDateTime viewedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -53,7 +53,7 @@ public class ApprovalHistory {
     public ApprovalHistory(Long document, Long actor, ActionTypeEnum actionType, String comment, ApprovalHistory parent) {
         this.document = document;
         this.actor = actor;
-        this.openDate = LocalDateTime.now();
+        this.viewedAt = LocalDateTime.now();
         this.actionType = actionType;
         this.comment = comment;
         this.parent = parent;

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalReferrer.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalReferrer.java
@@ -5,7 +5,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Column;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,5 +35,9 @@ public class ApprovalReferrer {
         this.document = document;
         this.referrer = referrer;
         this.viewedAt = viewedAt;
+    }
+
+    public void updateViewedAt() {
+        this.viewedAt = LocalDateTime.now();
     }
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
@@ -26,4 +26,8 @@ public interface ApprovalLineRepository extends JpaRepository<ApprovalLine, Long
     void updateLineStatusByDocumentAndSequence(Long docId, int sequence, LineStatusEnum lineStatusEnum);
 
     Optional<ApprovalLine> findByDocumentAndSequence(Long docId, int sequence);
+
+    Optional<ApprovalLine> findByDocumentAndApprover(Long document, Long approver);
+
+    boolean existsByDocumentAndApprover(Long document, Long approver);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalReferrerRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalReferrerRepository.java
@@ -4,7 +4,12 @@ import com.whatthefork.approvalsystem.domain.ApprovalReferrer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ApprovalReferrerRepository extends JpaRepository<ApprovalReferrer, Long> {
     List<ApprovalReferrer> findByDocumentOrderByViewedAt(Long documentId);
+
+    ApprovalReferrer findByDocument(Long document);
+
+    Optional<ApprovalReferrer> findByDocumentAndReferrer(Long document, Long referrer);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
@@ -177,6 +177,49 @@ public class DocumentService {
        return responseDto;
     }
 
+    //     기안자, 결재자, 참조자 아니면 읽지 못 하게.
+//     그 후 ApprovalHistory에 action은 결재자, READ로 변경하고 읽은 시간도 추가하는 로그를 남기는 메소드 생성
+    //  ActionTypeEnum.READ는 새로운 로그를 추가하는 행위 (상태 변경 아님)
+//  ApprovalHistory: READ 로그 기록. (문서 열람 시간 추적)
+//  ApprovalReferrer: 참조자가 열람 시 viewedAt 필드를 현재 시간으로 업데이트.
+//  ApprovalLine: 결재자가 열람해도 LineStatus는 WAIT 상태 유지.
+    public void writeHistory(Long docId, Long memberId) {
+
+        // 문서가 존재하는지
+        ApprovalDocument approvalDocument = approvalDocumentRepository.findById(docId).orElseThrow(
+                () -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND)
+        );
+
+        // 기안자 본인이면 로그 기록 하지 않음
+        if(approvalDocument.isSameDrafter(memberId)) {
+            return;
+        }
+
+        // 이 사람이 결재자인지
+        boolean isApprover = approvalLineRepository.existsByDocumentAndApprover(docId, memberId);
+
+        // 이 사람이 참조자인지, 참조자가 아니면 null 반환
+        ApprovalReferrer approvalReferrer = approvalReferrerRepository.findByDocumentAndReferrer(docId, memberId)
+                .orElse(null);
+
+        // 둘다 아니면 에러 처리
+        if(!isApprover && approvalReferrer == null) {
+            throw new BusinessException(ErrorCode.NO_READ_AUTHORIZATION);
+        }
+
+        // 참조자일 경우 읽은 시간 설정
+        if(approvalReferrer != null) {
+            approvalReferrer.updateViewedAt();
+        }
+
+        ApprovalHistory approvalHistory = ApprovalHistory.builder()
+                .document(docId)
+                .actor(memberId)
+                .actionType(ActionTypeEnum.READ)
+                .build();
+        approvalHistoryRepositoy.save(approvalHistory);
+    }
+
     @Transactional(readOnly = true)
     public Page<DocumentListResponseDto> getTempDocumentList(Long memberId, Pageable pageable) {
         Page<ApprovalDocument> documentList = approvalDocumentRepository.findByDocStatusAndDrafterOrderByCreatedAtDesc(DocStatusEnum.TEMP, memberId, pageable);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #71 

## #️⃣ 작업 내용

- 결재자 및 참조자가 문서를 상세 조회할 때 ApprovalHistory에 READ 로그를 적재하여 열람 시점을 기록
- 참조자가 문서를 열람할 때마다 ApprovalReferrer 테이블의 viewedAt 필드를 최신 시간으로 갱신하는 로직 추가
- 기안자, 결재자, 참조자가 아닌 제3자가 문서를 조회하려 할 때 예외를 발생시키는 로직 추가
- 기안자 본인이 문서를 조회하는 경우에는 로그가 쌓이지 않도록 처리
