### PR TITLE
[APPR-61] 결재 대기함, 기결재함, 참조 문서함 기안 페이징 조회 비즈니스 로직 구현

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/common/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     APPROVER_REQUIRED(HttpStatus.BAD_REQUEST, "D004", "결재자를 지정해야 합니다."),
     INVALID_APPROVER_COUNT(HttpStatus.BAD_REQUEST, "D005", "결재자는 반드시 3명이어야 합니다."),
     DRAFTER_EQUALS_APPROVER(HttpStatus.BAD_REQUEST, "D006", "본인은 결재자로 등록할 수 없습니다."),
+    NOT_FOUND_TO_APPROVE(HttpStatus.NOT_FOUND, "D007", "결재할 문서가 없습니다."),
 
     // Approval
     CANNOT_CANCEL_SUBMIT(HttpStatus.BAD_REQUEST, "P001", "결재자가 읽은 문서는 상신을 취소할 수 없습니다."),

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -71,4 +71,25 @@ public class DocumentController {
         Page<DocumentListResponseDto> documentList = documentService.getClosedDocumentList(memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(documentList));
     }
+
+    @GetMapping("/pending")
+    public ResponseEntity<ApiResponse> getDocumentsToApprove(/*Long memberId*/ Pageable pageable) {
+        Long memberId = 101L;
+        Page<DocumentListResponseDto> documentList = documentService.getDocumentsToApprove(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(documentList));
+    }
+
+    @GetMapping("/processed")
+    public ResponseEntity<ApiResponse> getProcessedDocuments(/*Long memberId*/ Pageable pageable) {
+        Long memberId = 101L;
+        Page<DocumentListResponseDto> documentList = documentService.getProcessedDocuments(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(documentList));
+    }
+
+    @GetMapping("/referenced")
+    public ResponseEntity<ApiResponse> getReferencedDocuments(/*Long memberId*/ Pageable pageable) {
+        Long memberId = 101L;
+        Page<DocumentListResponseDto> documentList = documentService.getReferencedDocuments(memberId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(documentList));
+    }
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalReferrer.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalReferrer.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Column;
+import jakarta.validation.constraints.Max;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +26,7 @@ public class ApprovalReferrer {
     private Long document;
 
     // 참조자(결재 권한 없음, 읽을 수만 있으며 결재선 상태에 영향 X), Member 객체 간접 참조
+    @Max(value = 5)
     @Column(name = "referrer_id", nullable = false)
     private Long referrer;
 

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalDocumentRepository.java
@@ -1,10 +1,13 @@
 package com.whatthefork.approvalsystem.repository;
 
 import com.whatthefork.approvalsystem.domain.ApprovalDocument;
+import com.whatthefork.approvalsystem.domain.ApprovalLine;
 import com.whatthefork.approvalsystem.enums.DocStatusEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +22,35 @@ public interface ApprovalDocumentRepository extends JpaRepository<ApprovalDocume
     Page<ApprovalDocument> findByDrafterAndDocStatusInOrderByCreatedAtDesc(Long drafter, List<DocStatusEnum> statusEnumList, Pageable pageable);
 
     Optional<ApprovalDocument> findByIdAndCurrentSequence(Long docId, int currentSequence);
+
+    // 우선 전체 문서중, 멤버ID가 포함되고 그 포함된 결재선의 시퀀스와 문서의 시퀀스가 같은 것들의 문서를 불러와야함
+    @Query("SELECT d FROM ApprovalDocument d " +
+            "JOIN ApprovalLine l ON d.id = l.document " +
+            "WHERE l.approver = :memberId " +
+            "AND d.currentSequence = l.sequence " +
+            "AND d.docStatus = 'IN_PROGRESS'")
+    Page<ApprovalDocument> findDocumentsToApprove(Long memberId, Pageable pageable);
+
+    /*
+     * 1. History의 기안 id = Document의 기안 id
+     * 2. History의 actor = memberId
+     * 3. History에 타입이 APPROVE 혹은 REJECT 인것
+     * 4. Document에 TEMP만 아니면 됨
+     * */
+    @Query(" SELECT DISTINCT d FROM ApprovalDocument d " +
+            "JOIN ApprovalHistory h on d.id = h.document " +
+            "WHERE h.actor = :memberId " +
+            "AND h.actionType IN ('APPROVE', 'REJECT')")
+    Page<ApprovalDocument> findProcessedDocuments(Long memberId, Pageable pageable);
+
+    /*
+     * 1. Referrer의 기안 id = Document의 기안 id
+     * 2. Refferer의 referrer = memberId
+     * 3.
+     * */
+    @Query("SELECT d FROM ApprovalDocument d " +
+            "JOIN ApprovalReferrer r on d.id = r.document " +
+            "WHERE r.referrer = :memberId " +
+            "AND d.docStatus != 'TEMP'")
+    Page<ApprovalDocument> findReferencedDocuments(Long memberId, Pageable pageable);
 }

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/repository/ApprovalLineRepository.java
@@ -1,8 +1,6 @@
 package com.whatthefork.approvalsystem.repository;
 
-import com.whatthefork.approvalsystem.domain.ApprovalDocument;
 import com.whatthefork.approvalsystem.domain.ApprovalLine;
-import com.whatthefork.approvalsystem.enums.ActionTypeEnum;
 import com.whatthefork.approvalsystem.enums.LineStatusEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/service/ApprovalService.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/service/ApprovalService.java
@@ -5,12 +5,14 @@ import com.whatthefork.approvalsystem.common.error.ErrorCode;
 import com.whatthefork.approvalsystem.domain.ApprovalDocument;
 import com.whatthefork.approvalsystem.domain.ApprovalHistory;
 import com.whatthefork.approvalsystem.domain.ApprovalLine;
+import com.whatthefork.approvalsystem.dto.response.DocumentListResponseDto;
 import com.whatthefork.approvalsystem.enums.ActionTypeEnum;
 import com.whatthefork.approvalsystem.enums.LineStatusEnum;
 import com.whatthefork.approvalsystem.repository.ApprovalDocumentRepository;
 import com.whatthefork.approvalsystem.repository.ApprovalHistoryRepositoy;
 import com.whatthefork.approvalsystem.repository.ApprovalLineRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -116,6 +118,7 @@ public class ApprovalService {
             document.nextSequence();
         } else {
             document.completeApproval();
+            // annualRepository.findByMember(memberId)로 불러와서, annualLeave.decreaseAnnual((int) 휴가 종료일 - 휴가 시작일)
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #77 

## #️⃣ 작업 내용

- 결재 대기함 : 현재 로그인한 사용자의 결재 차례가 도래한 문서만 필터링하여 조회
- 기결재함 : 사용자가 직접 승인 또는 반려 처리하여 결재 행위가 완료된 문서 목록을 조회
- 참조 문서함 : 참조자로 지정된 문서를 조회하되, 작성 중인 임시 문서는 제외하고 상신된 문서만 노출되도록 처리
- `Pageable`을 적용하여 대량의 문서 조회 시 페이징 처리가 가능하도록 구현
