### PR TITLE
[APPR-80] Feign Client로 memberName 추출 후 각 문서에 해당하는 기안자, 결재자, 참조자 이름 주입

### DIFF
--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/controller/DocumentController.java
@@ -42,7 +42,7 @@ public class DocumentController {
     public ResponseEntity<ApiResponse> createDocument(
             @AuthenticationPrincipal String memberId,
             @RequestBody @Valid CreateDocumentRequestDto requestDto) {
-        Long docId = documentService.createDocument(Long.valueOf(memberId), requestDto);
+        Long docId = documentService.createDocument(memberId, requestDto);
         return ResponseEntity.ok(ApiResponse.success(docId));
     }
 
@@ -110,10 +110,10 @@ public class DocumentController {
     })
     @GetMapping("/{docId}")
     public ResponseEntity<ApiResponse> getDocumentDetail(
-            @AuthenticationPrincipal String memberId,
+            @AuthenticationPrincipal String memberIdStr,
             @PathVariable Long docId) {
-        documentService.writeReadHistory(docId, Long.valueOf(memberId));
-        DocumentDetailResponseDto response = documentService.readDetailDocument(Long.valueOf(memberId), docId);
+        documentService.writeReadHistory(docId, memberIdStr);
+        DocumentDetailResponseDto response = documentService.readDetailDocument(memberIdStr, docId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalDocument.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalDocument.java
@@ -31,6 +31,9 @@ public class ApprovalDocument {
     @Column(name = "drafter_id", nullable = false)
     private Long drafter;
 
+    @Column(name = "drafter_name", nullable = false)
+    private String drafterName;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "doc_status", nullable = false)
     private DocStatusEnum docStatus; // ENUM: TEMP, IN_PROGRESS, APPROVED, REJECTED
@@ -60,7 +63,7 @@ public class ApprovalDocument {
     private boolean isDeleted;
 
     @Builder
-    public ApprovalDocument(Long drafter, DocStatusEnum docStatus, String title, String content, Long version, int currentSequence, LocalDateTime createdAt, LocalDate startVacationDate, LocalDate endVacationDate) {
+    public ApprovalDocument(Long drafter, DocStatusEnum docStatus, String title, String content, Long version, int currentSequence, LocalDateTime createdAt, LocalDate startVacationDate, LocalDate endVacationDate, String drafterName) {
         this.drafter = drafter;
         this.docStatus = docStatus;
         this.title = title;
@@ -70,6 +73,7 @@ public class ApprovalDocument {
         this.createdAt = createdAt;
         this.startVacationDate = startVacationDate;
         this.endVacationDate = endVacationDate;
+        this.drafterName = drafterName;
     }
 
     public void submit() {

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalHistory.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/domain/ApprovalHistory.java
@@ -34,6 +34,9 @@ public class ApprovalHistory {
     @Column(name = "actor_id", nullable = false)
     private Long actor;
 
+    @Column(name = "actor_name",  nullable = false)
+    private String actorName;
+
     @Column(nullable = false)
     private LocalDateTime viewedAt;
 
@@ -50,9 +53,10 @@ public class ApprovalHistory {
     private ApprovalHistory parent;
 
     @Builder
-    public ApprovalHistory(Long document, Long actor, ActionTypeEnum actionType, String comment, ApprovalHistory parent) {
+    public ApprovalHistory(Long document, Long actor, ActionTypeEnum actionType, String comment, ApprovalHistory parent, String actorName) {
         this.document = document;
         this.actor = actor;
+        this.actorName = actorName;
         this.viewedAt = LocalDateTime.now();
         this.actionType = actionType;
         this.comment = comment;

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentDetailResponseDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/dto/response/DocumentDetailResponseDto.java
@@ -20,6 +20,7 @@ public class DocumentDetailResponseDto {
 
     // 기안자 정보
     private Long drafterId;
+    private String drafterName;
 
     // 날짜 정보
     private LocalDate startVacationDate;

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/client/AnnualLeaveFeignClient.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/client/AnnualLeaveFeignClient.java
@@ -5,7 +5,6 @@ import com.whatthefork.approvalsystem.feign.dto.LeaveAnnualRequestDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "attendancetracking", url="http://localhost:8000", configuration = FeignConfig.class)
 public interface AnnualLeaveFeignClient {

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/client/UserFeignClient.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/client/UserFeignClient.java
@@ -1,0 +1,16 @@
+package com.whatthefork.approvalsystem.feign.client;
+
+import com.whatthefork.approvalsystem.common.ApiResponse;
+import com.whatthefork.approvalsystem.common.config.FeignConfig;
+import com.whatthefork.approvalsystem.feign.dto.UserDetailResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "userservice", url="http://localhost:8000", configuration = FeignConfig.class)
+public interface UserFeignClient {
+
+    @GetMapping("/api/v1/user-service/users/{userId}")
+    ApiResponse<UserDetailResponse> findUserDetail(@PathVariable("userId") Long memberId);
+}
+

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/dto/UserDetailResponse.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/dto/UserDetailResponse.java
@@ -1,0 +1,10 @@
+package com.whatthefork.approvalsystem.feign.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDetailResponse {
+    private UserDto user;
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/dto/UserDto.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/feign/dto/UserDto.java
@@ -1,0 +1,11 @@
+package com.whatthefork.approvalsystem.feign.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserDto {
+    private Long id;
+    private String name;
+}

--- a/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
+++ b/approval-system/src/main/java/com/whatthefork/approvalsystem/service/DocumentService.java
@@ -1,5 +1,6 @@
 package com.whatthefork.approvalsystem.service;
 
+import com.whatthefork.approvalsystem.common.ApiResponse;
 import com.whatthefork.approvalsystem.common.error.BusinessException;
 import com.whatthefork.approvalsystem.common.error.ErrorCode;
 import com.whatthefork.approvalsystem.domain.ApprovalDocument;
@@ -16,6 +17,8 @@ import com.whatthefork.approvalsystem.dto.response.ReferrerResponseDto;
 import com.whatthefork.approvalsystem.enums.ActionTypeEnum;
 import com.whatthefork.approvalsystem.enums.DocStatusEnum;
 import com.whatthefork.approvalsystem.enums.LineStatusEnum;
+import com.whatthefork.approvalsystem.feign.client.UserFeignClient;
+import com.whatthefork.approvalsystem.feign.dto.UserDetailResponse;
 import com.whatthefork.approvalsystem.repository.ApprovalDocumentRepository;
 import com.whatthefork.approvalsystem.repository.ApprovalHistoryRepositoy;
 import com.whatthefork.approvalsystem.repository.ApprovalLineRepository;
@@ -30,7 +33,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-/* 12.06 UserDetails 부분이 완성이 되면 모든 메소드의 Long userId는 Userdetials로 교체할 것 */
 @Service
 @RequiredArgsConstructor
 public class DocumentService {
@@ -40,19 +42,22 @@ public class DocumentService {
     private final ApprovalHistoryRepositoy approvalHistoryRepositoy;
     private final ApprovalReferrerRepository approvalReferrerRepository;
     private final MemberRepository memberRepository;
+    private final UserFeignClient userFeignClient;
 
     @Transactional
-    public Long createDocument(Long memberId, CreateDocumentRequestDto requestDto) {
+    public Long createDocument(String memberIdStr, CreateDocumentRequestDto requestDto) {
+
+        Long memberId = Long.parseLong(memberIdStr);
+        String drafterName = getUserName(memberId);
 
         // 결재선 저장
         List<Long> approvalIds = requestDto.getApproverIds();
         validateApproverList(approvalIds, memberId);
 
-        /* (추후 구현) memberRepository에서 해당 멤버가 존재하는지 getDraftId로 판독 */
-
         // 기안 작성
         ApprovalDocument approvalDocument = ApprovalDocument.builder()
                         .drafter(memberId)
+                        .drafterName(drafterName)
                         .title(requestDto.getTitle())
                         .content(requestDto.getContent())
                         .createdAt(LocalDateTime.now())
@@ -86,6 +91,7 @@ public class DocumentService {
         ApprovalHistory approvalHistory = ApprovalHistory.builder()
                 .document(docId)
                 .actor(memberId)
+                .actorName(getUserName(memberId))
                 .actionType(ActionTypeEnum.CREATE)
                 .build();
 
@@ -111,6 +117,7 @@ public class DocumentService {
         ApprovalHistory approvalHistory = ApprovalHistory.builder()
                 .document(docId)
                 .actor(memberId)
+                .actorName(getUserName(memberId))
                 .actionType(ActionTypeEnum.UPDATE)
                 .comment(requestDto.getUpdateComment())
                 .build();
@@ -127,9 +134,10 @@ public class DocumentService {
         approvalDocument.deleteDocument();
     }
 
-
     @Transactional(readOnly = true)
-    public DocumentDetailResponseDto readDetailDocument(Long memberId, Long docId) {
+    public DocumentDetailResponseDto readDetailDocument(String memberIdStr, Long docId) {
+        Long memberId = Long.parseLong(memberIdStr);
+
        ApprovalDocument document = approvalDocumentRepository.findById(docId).orElseThrow(
                 () -> new BusinessException(ErrorCode.DOCUMENT_NOT_FOUND)
         );
@@ -149,7 +157,7 @@ public class DocumentService {
         List<ApprovalLineResponseDto> approvalLinesResponseDto = approvalLines.stream()
                 .map(line -> ApprovalLineResponseDto.builder()
                         .approverId(line.getApprover())
-                        .approverName("임시 이름") // 12.08 memberRepository 연동 후 수정 예정
+                        .approverName(getUserName(line.getApprover()))
                         .sequence(line.getSequence())
                         .status(line.getLineStatus())
                         .approvedAt(line.getApprovedAt())
@@ -160,7 +168,7 @@ public class DocumentService {
         List<ReferrerResponseDto> referrerResponseDto = referrers.stream().map(
                 referrer -> ReferrerResponseDto.builder()
                         .referrerId(referrer.getReferrer())
-                        .referrerName("임시 이름") // 12.08 memberRepository 연동 후 수정
+                        .referrerName(getUserName(referrer.getReferrer()))
                         .viewedAt(referrer.getViewedAt())
                         .build()
         ).toList();
@@ -171,6 +179,7 @@ public class DocumentService {
                 .content(document.getContent())
                 .docStatus(document.getDocStatus())
                 .drafterId(document.getDrafter())
+                .drafterName(getUserName(document.getDrafter()))
                 .startVacationDate(document.getStartVacationDate())
                 .endVacationDate(document.getEndVacationDate())
                 .createdAt(document.getCreatedAt())
@@ -179,14 +188,10 @@ public class DocumentService {
                 .build();
     }
 
-    //     기안자, 결재자, 참조자 아니면 읽지 못 하게.
-//     그 후 ApprovalHistory에 action은 결재자, READ로 변경하고 읽은 시간도 추가하는 로그를 남기는 메소드 생성
-    //  ActionTypeEnum.READ는 새로운 로그를 추가하는 행위 (상태 변경 아님)
-//  ApprovalHistory: READ 로그 기록. (문서 열람 시간 추적)
-//  ApprovalReferrer: 참조자가 열람 시 viewedAt 필드를 현재 시간으로 업데이트.
-//  ApprovalLine: 결재자가 열람해도 LineStatus는 WAIT 상태 유지.
     @Transactional
-    public void writeReadHistory(Long docId, Long memberId) {
+    public void writeReadHistory(Long docId, String memberIdStr) {
+
+        Long memberId = Long.valueOf(memberIdStr);
 
         // 문서가 존재하는지
         ApprovalDocument approvalDocument = approvalDocumentRepository.findById(docId).orElseThrow(
@@ -218,6 +223,7 @@ public class DocumentService {
         ApprovalHistory approvalHistory = ApprovalHistory.builder()
                 .document(docId)
                 .actor(memberId)
+                .actorName(getUserName(memberId))
                 .actionType(ActionTypeEnum.READ)
                 .build();
         approvalHistoryRepositoy.save(approvalHistory);
@@ -249,9 +255,6 @@ public class DocumentService {
     @Transactional(readOnly = true)
     public Page<DocumentListResponseDto> getDocumentsToApprove(Long memberId, Pageable pageable) {
 
-        // 우선 전체 문서중, 멤버ID가 포함되고 그 포함된 결재선의 시퀀스와 문서의 시퀀스가 같은 것들의 문서를 불러와야함
-        // 그럼 그 문서를 ResponseDTO에 담아서 return
-        // 접근 권한 넣기
         Page<ApprovalDocument> documentList = approvalDocumentRepository.findDocumentsToApprove(memberId, pageable);
         return getResponseDto(documentList);
     }
@@ -260,12 +263,6 @@ public class DocumentService {
     @Transactional(readOnly = true)
     public Page<DocumentListResponseDto> getProcessedDocuments(Long memberId, Pageable pageable) {
 
-        /*
-        * 1. History의 기안 id = Document의 기안 id
-        * 2. History의 actor = memberId
-        * 3. History에 타입이 APPROVE 혹은 REJECT 인것
-        * 4. Document에 TEMP만 아니면 됨
-        * */
         Page<ApprovalDocument> documentList = approvalDocumentRepository.findProcessedDocuments(memberId, pageable);
         return getResponseDto(documentList);
     }
@@ -273,11 +270,7 @@ public class DocumentService {
     /* 참조 문서함(참조자로 지정된 문서 목록) */
     @Transactional(readOnly = true)
     public Page<DocumentListResponseDto> getReferencedDocuments(Long  memberId, Pageable pageable) {
-        /*
-        * 1. Referrer의 기안 id = Document의 기안 id
-        * 2. Refferer의 referrer = memberId
-        * 3.
-        * */
+
         Page<ApprovalDocument> documentList = approvalDocumentRepository.findReferencedDocuments(memberId, pageable);
         return getResponseDto(documentList);
 
@@ -363,6 +356,21 @@ public class DocumentService {
                     .build();
 
             approvalLineRepository.save(newLine);
+        }
+    }
+
+    private String getUserName(Long userId) {
+
+        try {
+            ApiResponse<UserDetailResponse> response = userFeignClient.findUserDetail(userId);
+
+            if(response != null && response.getData() != null && response.getData().getUser() != null) {
+                return response.getData().getUser().getName();
+            }
+            return "알 수 없는 유저입니다.";
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            return "알 수 없는 유저입니다.";
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #107 

## #️⃣ 작업 내용
- 기안 작성 메소드 `createDocument`에 기안자 이름 주입
- 행위 로그 작성 메소드 `writeReadHistory`에 행위자 이름 주입
- 기안 상세 조회 메소드 `readDetailsDocument`에 기안자, 결재자 및 참조자 이름 조회되도록 구현

